### PR TITLE
Fix encoding of validity fields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .python-version
+.eggs/
 *.egg-info/
 build/
 dist/

--- a/certbuilder/__init__.py
+++ b/certbuilder/__init__.py
@@ -864,6 +864,15 @@ class CertificateBuilder(object):
 
         signature_algorithm_id = '%s_%s' % (self._hash_algo, signature_algo)
 
+        # RFC 3280 4.1.2.5
+        def _make_validity_time(dt):
+            if dt < datetime(2050, 1, 1, tzinfo=timezone.utc):
+                value = x509.Time(name='utc_time', value=dt)
+            else:
+                value = x509.Time(name='general_time', value=dt)
+
+            return value
+
         def _make_extension(name, value):
             return {
                 'extn_id': name,
@@ -890,8 +899,8 @@ class CertificateBuilder(object):
             },
             'issuer': self._issuer,
             'validity': {
-                'not_before': x509.Time(name='utc_time', value=self._begin_date),
-                'not_after': x509.Time(name='utc_time', value=self._end_date),
+                'not_before': _make_validity_time(self._begin_date),
+                'not_after': _make_validity_time(self._end_date),
             },
             'subject': self._subject,
             'subject_public_key_info': self._subject_public_key,

--- a/tox.ini
+++ b/tox.ini
@@ -5,28 +5,20 @@ envlist = py26,py27,py32,py33,py34,py35,py36,pypy
 deps =
     asn1crypto
     oscrypto
-    py26:
-        coverage
-    py27:
-        flake8
-        coverage
-    py32:
-        flake8
-    py33:
-        flake8
-        coverage
-    py34:
-        flake8
-        coverage
-    py35:
-        flake8
-        coverage
-    py36:
-        flake8
-        coverage
-    pypy:
-        flake8
-        coverage
+    py26: coverage
+    py27: flake8
+          coverage
+    py32: flake8
+    py33: flake8
+          coverage
+    py34: flake8
+          coverage
+    py35: flake8
+          coverage
+    py36: flake8
+          coverage
+    pypy: flake8
+          coverage
 commands = {envpython} run.py ci
 
 [pep8]


### PR DESCRIPTION
Dates in 2050 or later must be encoded as GeneralizedTime (RFC 3280
4.1.2.5). Without this fix, certs with an expiration date of 2050+ will be interpreted as expiring in 1950+.