### PR TITLE
Mark 'Time Stamping' extended key usage extension as critical

### DIFF
--- a/certbuilder/__init__.py
+++ b/certbuilder/__init__.py
@@ -706,9 +706,10 @@ class CertificateBuilder(object):
 
         See the definition of asn1crypto.x509.Extension to determine the
         appropriate object type for a given extension. Extensions are marked
-        as critical when RFC 5280 or RFC 6960 indicate so. If an extension is
-        validly marked as critical or not (such as certificate policies and
-        extended key usage), this class will mark it as non-critical.
+        as critical when RFC 3161, RFC 5280 or RFC 6960 indicate so. If an
+        extension is validly marked as critical or not (such as certificate
+        policies and extended key usage), this class will mark it
+        as non-critical.
 
         :param name:
             A unicode string of an extension id name from
@@ -764,8 +765,9 @@ class CertificateBuilder(object):
 
         :return:
             A bool indicating the correct value of the critical flag for
-            an extension, based on information from RFC 5280 and RFC 6960. The
-            correct value is based on the terminology SHOULD or MUST.
+            an extension, based on information from RFC 3161, RFC 5280 and
+            RFC 6960. The correct value is based on the terminology
+            SHOULD or MUST.
         """
 
         if name == 'subject_alt_name':
@@ -773,6 +775,9 @@ class CertificateBuilder(object):
 
         if name == 'basic_constraints':
             return self.ca is True
+
+        if name == 'extended_key_usage':
+            return 'time_stamping' in self.extended_key_usage
 
         return {
             'subject_directory_attributes': False,

--- a/tests/test_certificate_builder.py
+++ b/tests/test_certificate_builder.py
@@ -288,6 +288,27 @@ class CertificateBuilderTests(unittest.TestCase):
         self.assertEqual(new_certificate['tbs_certificate']['validity']['not_before'].name, 'general_time')
         self.assertEqual(new_certificate['tbs_certificate']['validity']['not_after'].name, 'general_time')
 
+    def test_tsa_certificate_extended_key_usage(self):
+        public_key, private_key = self.ec_secp256r1
+
+        builder = CertificateBuilder(
+            {
+                'country_name': 'US',
+                'state_or_province_name': 'Massachusetts',
+                'locality_name': 'Newbury',
+                'organization_name': 'Codex Non Sufficit LC',
+                'common_name': 'Will Bond',
+            },
+            public_key
+        )
+        builder.self_signed = True
+        builder.extended_key_usage = set(('time_stamping',))
+        certificate = builder.build(private_key)
+        der_bytes = certificate.dump()
+
+        new_certificate = asn1crypto.x509.Certificate.load(der_bytes)
+        self.assertEqual(set(['key_usage', 'extended_key_usage']), new_certificate.critical_extensions)
+
     # Cached key pairs
     @lazy_class_property
     def ec_secp256r1(self):


### PR DESCRIPTION
As stated in section 2.3 of RFC3161:
>   The corresponding certificate MUST contain only one instance of the
>   extended key usage field extension as defined in [RFC2459] Section
>   4.2.1.13 with KeyPurposeID having value:
>
>   id-kp-timeStamping.  This extension MUST be critical.