### PR TITLE
Adding feature to allow a callable as the signing key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 *.egg-info/
 .eggs/
 .tox/
+.idea/
 __pycache__/
 build/
 dist/
 tests/output/
+venv/
 *.pyc
 .coverage
 .DS_Store

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,16 @@
 > >         is self-signed, this should be the private key that matches the
 > >         public key, otherwise it needs to be the issuer's private key.
 > >
+> >         Alternatively, a callable may be provided to sign the certificate.
+> >         In this case, the callable must have an attribute `algorithm` that
+> >         identifies the signature algorithm.  This will be called as:
+> > 
+> >             signing_private_key(data, hash_algorithm)
+> > 
+> >         data – A byte string of the data the signature is for
+> >         hash_algorithm – A unicode string of "md5", "sha1", "sha224", "sha256", "sha384" or "sha512"
+> >         The callable should return a byte string of the signature.
+> > 
 > >     :return:
 > >         An asn1crypto.x509.Certificate object of the newly signed
 > >         certificate


### PR DESCRIPTION
I made modifications to the CertificateBuilder.build to allow for a callable to be used as the private key.  This will allow downstream usage of a key that leverages an external process or custom code to calculate the signature while maintaining the core functionality of assembling the x509 certificate.

Example usage:
[test_callable_key.py](https://github.com/wbond/certbuilder/files/6172463/test_callable_key.py.txt)

I tried to figure out how to verify that the signature is valid, but couldn't find a way to test it that was super complicated.

While the example is mostly pointless, this feature could be useful when attempting to use a key maintained in an external key store, such as with a hardware security module (HSM), [AWS KMS](https://aws.amazon.com/kms/), or other key signing service.

I initially asked if this was possible in pyca/cryptography#5921, which I found to be extremely difficult to try to build in.

Thanks for your consideration!